### PR TITLE
Adapting to 7_4_0.

### DIFF
--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -10,8 +10,6 @@
   <class name="edm::Wrapper<std::vector<mitedm::DecayPart> >"/>
   <class name="edm::Ptr<mitedm::BasePart>"/>
   <class name="edm::Ptr<reco::Vertex>"/>
-  <class name="edm::Ptr<reco::Track>"/>
-  <class name="std::vector<edm::Ptr<reco::Track> >"/>
   <class name="edm::Wrapper<std::vector<edm::Ptr<reco::Track> > >"/>
   <class name="mitedm::DaughterData"/>
   <class name="mitedm::StableData"/>

--- a/GBRTrain/test/applyenergy.C
+++ b/GBRTrain/test/applyenergy.C
@@ -1,7 +1,7 @@
 // #define private public
 // #define protected public
 
-#if !defined(__CINT__) || defined(__MAKECINT__)
+#if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <iostream>
 #include "RooRealVar.h"
 #include "RooDataSet.h"

--- a/TrackerElectrons/src/SimpleTrackListMergerGsf.cc
+++ b/TrackerElectrons/src/SimpleTrackListMergerGsf.cc
@@ -487,11 +487,11 @@ void SimpleTrackListMergerGsf::produce(edm::Event& e, const edm::EventSetup& es)
       // fill TrackingRecHits
       std::vector<const TrackingRecHit*>& iHits = rh1[track]; 
       unsigned nh1 = iHits.size();
+      tx.setHits(refTrkHits_, outputTrkHits_->size(), nh1);
       for (unsigned ih=0; ih<nh1; ++ih) { 
 	const TrackingRecHit* hit = iHits[ih];
 	//for(trackingRecHit_iterator hit = itB; hit != itE; ++hit) {
 	outputTrkHits_->push_back(hit->clone());
-	tx.add(TrackingRecHitRef(refTrkHits_, outputTrkHits_->size() - 1));
       }
       trackRefs_[current] = reco::GsfTrackRef(refTrks_, outputTrks_->size() - 1);
 
@@ -543,10 +543,10 @@ void SimpleTrackListMergerGsf::produce(edm::Event& e, const edm::EventSetup& es)
       // fill TrackingRecHits
       std::vector<const TrackingRecHit*> &jHits = rh2[track]; 
       unsigned nh2 = jHits.size();
+      tx.setHits(refTrkHits_, outputTrkHits_->size(), nh2);
       for (unsigned jh=0; jh<nh2; ++jh) { 
 	const TrackingRecHit* hit = jHits[jh];
 	outputTrkHits_->push_back(hit->clone());
-	tx.add(TrackingRecHitRef(refTrkHits_, outputTrkHits_->size() - 1));
       }
       trackRefs_[current] = reco::GsfTrackRef(refTrks_, outputTrks_->size() - 1);
 


### PR DESCRIPTION
ROOT 6 changed the interpreter from CINT to CLING. All macros **CINT** and **MAKECINT** had to change to **CLING** and **ROOTCLING**.
