### PR TITLE
new EDProducers to relate various candidate collections through maps

### DIFF
--- a/Producers/interface/CandMappingProducer.h
+++ b/Producers/interface/CandMappingProducer.h
@@ -1,0 +1,31 @@
+//--------------------------------------------------------------------------------------------------
+// CandMappingProducer
+//
+// Produces a ValueMap<CandidatePtr> to connect two collections of same candidates
+//
+// Authors: Y.Iiyama
+//--------------------------------------------------------------------------------------------------
+
+#ifndef MITEDM_PRODUCERS_CANDMAPPINGPRODUCER_H
+#define MITEDM_PRODUCERS_CANDMAPPINGPRODUCER_H
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+class CandMappingProducer : public edm::EDProducer {
+  typedef edm::EDGetTokenT<reco::CandidateView> CandViewToken;
+  typedef edm::ValueMap<reco::CandidatePtr> CandPtrMap;
+
+ public:
+  CandMappingProducer(edm::ParameterSet const&);
+  ~CandMappingProducer() {}
+
+ private:
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+  CandViewToken sourceToken_;
+  CandViewToken targetToken_;
+};
+
+#endif

--- a/Producers/interface/MappingCandViewMerger.h
+++ b/Producers/interface/MappingCandViewMerger.h
@@ -1,0 +1,32 @@
+//--------------------------------------------------------------------------------------------------
+// MappingCandViewMerger
+//
+// Extension of CandViewMerger (CommonTools/CandAlgos/plugins/CandViewMerger.cc) which
+// produces the mapping from the original input collections to the output (clone) collection
+//
+// Authors: Y.Iiyama
+//--------------------------------------------------------------------------------------------------
+
+#ifndef MITEDM_PRODUCERS_MAPPINGCANDVIEWMERGER_H
+#define MITEDM_PRODUCERS_MAPPINGCANDVIEWMERGER_H
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+class MappingCandViewMerger : public edm::EDProducer {
+  typedef edm::EDGetTokenT<reco::CandidateView> CandViewToken;
+  typedef std::vector<CandViewToken> VCandViewToken;
+  typedef edm::ValueMap<reco::CandidatePtr> CandPtrMap;
+
+ public:
+  MappingCandViewMerger(edm::ParameterSet const&);
+  ~MappingCandViewMerger() {}
+
+ private:
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+  VCandViewToken srcTokens_;
+};
+
+#endif

--- a/Producers/src/CandMappingProducer.cc
+++ b/Producers/src/CandMappingProducer.cc
@@ -1,0 +1,48 @@
+#include "MitEdm/Producers/interface/CandMappingProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+CandMappingProducer::CandMappingProducer(edm::ParameterSet const& cfg) :
+  sourceToken_(consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("source"))),
+  targetToken_(consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("target")))
+{
+  produces<CandPtrMap>();
+}
+
+void
+CandMappingProducer::produce(edm::Event& event, edm::EventSetup const&)
+{
+  edm::Handle<reco::CandidateView> hSource;
+  edm::Handle<reco::CandidateView> hTarget;
+
+  event.getByToken(sourceToken_, hSource);
+  event.getByToken(targetToken_, hTarget);
+
+  std::auto_ptr<CandPtrMap> outMap(new CandPtrMap);
+  std::vector<reco::CandidatePtr> mapValues;
+
+  for (auto& source : *hSource) {
+    unsigned iKey(0);
+    for (; iKey != hTarget->size(); ++iKey) {
+      if (&hTarget->at(iKey) == &source) {
+        mapValues.emplace_back(hTarget, iKey);
+        break;
+      }
+    }
+    if (iKey == hTarget->size())
+      mapValues.push_back(reco::CandidatePtr());
+  }
+
+  CandPtrMap::Filler filler(*outMap);
+  filler.insert(hSource, mapValues.begin(), mapValues.end());
+  filler.fill();
+
+  event.put(outMap);
+}
+
+DEFINE_FWK_MODULE(CandMappingProducer);

--- a/Producers/src/MappingCandViewMerger.cc
+++ b/Producers/src/MappingCandViewMerger.cc
@@ -1,0 +1,63 @@
+#include "MitEdm/Producers/interface/MappingCandViewMerger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/CloneTrait.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+MappingCandViewMerger::MappingCandViewMerger(edm::ParameterSet const& cfg) :
+  srcTokens_()
+{
+  auto srcTags(cfg.getParameter<std::vector<edm::InputTag>>("src"));
+  for (auto&& tag : srcTags)
+    srcTokens_.push_back(consumes<reco::CandidateView>(tag));
+
+  produces<reco::CandidateCollection>();
+  produces<CandPtrMap>();
+}
+
+void
+MappingCandViewMerger::produce(edm::Event& event, edm::EventSetup const&)
+{
+  std::auto_ptr<reco::CandidateCollection> outCol(new reco::CandidateCollection);
+  std::auto_ptr<CandPtrMap> outMap(new CandPtrMap);
+
+  std::vector<edm::Handle<reco::CandidateView>> handles(srcTokens_.size());
+  std::vector<std::pair<unsigned, unsigned>> mapIntervals;
+
+  for (unsigned iS(0); iS != srcTokens_.size(); ++iS) {
+    auto& token(srcTokens_[iS]);
+
+    event.getByToken(token, handles[iS]);
+    auto& product(*handles[iS]);
+
+    mapIntervals.emplace_back(outCol->size(), outCol->size() + product.size());
+
+    for (auto&& cand : product)
+      outCol->push_back(cand.clone());
+  }
+
+  auto orphanHandle(event.put(outCol));
+  std::vector<reco::CandidatePtr> mapValues;
+
+  for (unsigned iKey(0); iKey != orphanHandle->size(); ++iKey)
+    mapValues.emplace_back(orphanHandle, iKey);
+
+  for (unsigned iS(0); iS != srcTokens_.size(); ++iS) {
+    CandPtrMap map;
+    CandPtrMap::Filler filler(map);
+    auto& interval(mapIntervals[iS]);
+
+    filler.insert(handles[iS], mapValues.begin() + interval.first, mapValues.begin() + interval.second);
+    filler.fill();
+
+    *outMap += map;
+  }
+  
+  event.put(outMap);
+}
+
+DEFINE_FWK_MODULE(MappingCandViewMerger);


### PR DESCRIPTION
Extensively using ValueMap<CandidatePtr> to resolve mapping from particleFlow to puppi.
