### PR TITLE
Helping the puppi mess

### DIFF
--- a/Producers/BuildFile.xml
+++ b/Producers/BuildFile.xml
@@ -10,6 +10,9 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/CaloRecHit"/>
+<use   name="DataFormats/Candidate">
+<use   name="DataFormats/ParticleFlowCandidate">
+<use   name="DataFormats/Math">
 <use   name="MagneticField/Engine"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="RecoTracker/Record"/>

--- a/Producers/interface/PuppiPhotonScaler.h
+++ b/Producers/interface/PuppiPhotonScaler.h
@@ -1,0 +1,47 @@
+#ifndef MitEdm_Producers_PuppiPhotonScaler_h
+#define MitEdm_Producers_PuppiPhotonScaler_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include <vector>
+
+// Adapted from CommonTools/PileupAlgos/PuppiPhoton
+
+// ------------------------------------------------------------------------------------------
+class PuppiPhotonScaler : public edm::stream::EDProducer<> {
+
+ public:
+  explicit PuppiPhotonScaler(const edm::ParameterSet&);
+  ~PuppiPhotonScaler();
+
+ typedef math::XYZTLorentzVector LorentzVector;
+ typedef std::vector<reco::PFCandidate> PFOutputCollection;
+ typedef edm::View<reco::PFCandidate> PFView;
+ typedef edm::View<reco::Candidate> CandidateView;
+ typedef std::vector<reco::PFCandidateRef> PFRefVector;
+ typedef edm::ValueMap<PFRefVector> PFRefVectorMap;
+ typedef edm::ValueMap<bool> BoolMap;
+
+ private:
+ virtual void produce(edm::Event&, const edm::EventSetup&);
+ bool matchPFCandidate(reco::PFCandidate const&, reco::Candidate const&) const;
+
+ edm::EDGetTokenT<PFView> tokenPFCandidates_;
+ edm::EDGetTokenT<PFView> tokenPuppiCandidates_;
+ edm::EDGetTokenT<CandidateView> tokenPhotonCandidates_;
+ edm::EDGetTokenT<PFRefVectorMap> tokenFootprints_;
+ edm::EDGetTokenT<BoolMap> tokenPhotonId_; 
+
+ double pt_;
+ std::vector<double> dRMatch_;
+ std::vector<unsigned> pdgIds_;
+ bool usePhotonId_;
+};
+
+#endif

--- a/Producers/src/PuppiPhotonScaler.cc
+++ b/Producers/src/PuppiPhotonScaler.cc
@@ -1,0 +1,169 @@
+#include "MitEdm/Producers/interface/PuppiPhotonScaler.h"
+
+// user include files
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+//#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
+//Main File
+
+typedef edm::ValueMap<reco::CandidatePtr> CandPtrMap;
+
+// ------------------------------------------------------------------------------------------
+PuppiPhotonScaler::PuppiPhotonScaler(const edm::ParameterSet& iConfig) :
+  tokenPFCandidates_(consumes<PFView>(iConfig.getParameter<edm::InputTag>("candName"))),
+  tokenPuppiCandidates_(consumes<PFView>(iConfig.getParameter<edm::InputTag>("puppiCandName"))),
+  tokenPhotonCandidates_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("photonName"))),
+  tokenFootprints_(consumes<PFRefVectorMap>(iConfig.getParameter<edm::InputTag>("footprintsName"))),
+  tokenPhotonId_(consumes<BoolMap>(iConfig.getParameter<edm::InputTag>("photonId"))),
+  pt_(iConfig.getParameter<double>("pt")),
+  dRMatch_(iConfig.getParameter<std::vector<double>>("dRMatch")),
+  pdgIds_(iConfig.getParameter<std::vector<unsigned>>("pdgids"))
+{
+  usePhotonId_ = !tokenPhotonId_.isUninitialized();
+
+  produces<PFOutputCollection>();
+  produces<CandPtrMap>(); 
+}
+
+// ------------------------------------------------------------------------------------------
+PuppiPhotonScaler::~PuppiPhotonScaler()
+{
+}
+
+// ------------------------------------------------------------------------------------------
+void
+PuppiPhotonScaler::produce(edm::Event& iEvent, const edm::EventSetup&)
+{
+  static const reco::PFCandidate dummySinceTranslateIsNotStatic;
+
+  edm::Handle<CandidateView> hPhoProduct;
+  iEvent.getByToken(tokenPhotonCandidates_, hPhoProduct);
+  const CandidateView *phoCol = hPhoProduct.product();
+
+  edm::Handle<PFRefVectorMap> hFPProduct;
+  iEvent.getByToken(tokenFootprints_, hFPProduct);
+  const PFRefVectorMap *footprints = hFPProduct.product();
+
+  edm::Handle<PFView> hPuppiProduct;
+  iEvent.getByToken(tokenPuppiCandidates_, hPuppiProduct);
+  const PFView *pupCol = hPuppiProduct.product();
+
+  edm::Handle<PFView> hPFProduct;
+  iEvent.getByToken(tokenPFCandidates_, hPFProduct);
+  const PFView *pfCol = hPFProduct.product();
+
+  if (pfCol->size() != pupCol->size())
+    throw cms::Exception("InvalidInput") << "Puppi collection size does not match the PF Collection size";
+
+  BoolMap const* photonId(0);
+  if(usePhotonId_) {
+    edm::Handle<BoolMap> hPhotonId;
+    iEvent.getByToken(tokenPhotonId_, hPhotonId);
+    photonId = hPhotonId.product();
+  }
+
+  std::vector<reco::PFCandidate const*> matchedPFs;
+  std::vector<uint16_t> matchedPFKeys;
+
+  int iC(0);
+  for (auto& photon : *phoCol) {
+    auto&& ptr(phoCol->ptrAt(iC++));
+
+    if (!photon.isPhoton())
+      continue;
+
+    if (photon.pt() < pt_)
+      continue;
+
+    if (usePhotonId_) {
+      if (!(*photonId)[ptr])
+        continue;
+    }
+
+    for (auto&& fpRef : (*footprints)[ptr]) {
+      auto key(fpRef.key());
+      auto& fpPF(*pfCol->ptrAt(key));
+
+      if (matchPFCandidate(fpPF, photon)) {
+        matchedPFKeys.push_back(key);
+        matchedPFs.push_back(&fpPF);
+      }
+    }
+  }
+
+  std::vector<reco::CandidatePtr> values(hPFProduct->size());
+  std::auto_ptr<PFOutputCollection> corrCandidates(new PFOutputCollection);
+
+  int iPF(0);
+  for (auto& pupCand : *pupCol) {
+    auto&& pupKey(pupCol->refAt(iPF++).key());
+
+    reco::PFCandidate pCand(pupCand);
+
+    float pWeight = 1.;
+
+    for (unsigned iKey(0); iKey != matchedPFKeys.size(); ++iKey) {
+      auto& key(matchedPFKeys[iKey]);
+
+      if (key != pupKey)
+        continue;
+
+      // are we sure we want just the last matched candidate??
+      if (pupCand.pt() != 0)
+        pWeight = matchedPFs[iKey]->pt() / pupCand.pt();
+
+      matchedPFs[iKey] = 0; // candidate matched by key; not used any more
+    }
+
+    LorentzVector pVec(pupCand.p4());
+    if(pupCand.pt() != 0.)
+      pVec.SetPxPyPzE(pupCand.px() * pWeight, pupCand.py() * pWeight, pupCand.pz() * pWeight, pupCand.energy() * pWeight);
+
+    pCand.setP4(pVec);
+    pCand.setSourceCandidatePtr(pupCand.sourceCandidatePtr(0));
+    corrCandidates->push_back(pCand);
+  }
+
+  // Add the missing pfcandidates
+  for (auto* pf : matchedPFs) {
+    if (!pf)
+      continue;
+
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(pf->pdgId());
+
+    reco::PFCandidate pCand(pf->charge(), pf->p4(), id);
+    pCand.setSourceCandidatePtr(pf->sourceCandidatePtr(0));
+    corrCandidates->push_back(pCand);
+  }
+
+  // Fill it into the event
+  edm::OrphanHandle<reco::PFCandidateCollection> oh(iEvent.put(corrCandidates));
+  for (unsigned iC(0); iC != pupCol->size(); ++iC)
+    values[iC] = reco::CandidatePtr(oh, iC);
+
+  std::auto_ptr<CandPtrMap> pfMap_p(new CandPtrMap());
+  CandPtrMap::Filler filler(*pfMap_p);
+  filler.insert(hPFProduct, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(pfMap_p);
+}
+
+// ------------------------------------------------------------------------------------------
+bool
+PuppiPhotonScaler::matchPFCandidate(reco::PFCandidate const& pf, reco::Candidate const& photon) const
+{
+  unsigned absId(std::abs(pf.pdgId()));
+  double dr(deltaR(pf.eta(), pf.phi(), photon.eta(), photon.phi()));
+  
+  for (unsigned iI(0); iI != pdgIds_.size(); ++iI) {
+    if (pdgIds_[iI] == absId && dr < dRMatch_[iI])
+      return true;
+  }
+  return false;
+}

--- a/Producers/src/SealModule.cc
+++ b/Producers/src/SealModule.cc
@@ -1,15 +1,14 @@
-// $Id: SealModule.cc,v 1.3 2010/05/03 11:37:49 bendavid Exp $
-
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "MitEdm/Producers/interface/HitDropper.h"
 #include "MitEdm/Producers/interface/HitDropperESProducer.h"
 #include "MitEdm/Producers/interface/SimpleTrackListMergerTransient.h"
-
+#include "MitEdm/Producers/interface/PuppiPhotonScaler.h"
 
 using namespace mitedm;
 
 DEFINE_FWK_EVENTSETUP_MODULE(HitDropperESProducer);
 TYPELOOKUP_DATA_REG(HitDropper);
 DEFINE_FWK_MODULE(SimpleTrackListMergerTransient);
+DEFINE_FWK_MODULE(PuppiPhotonScaler);


### PR DESCRIPTION
Puppi needs a special handling of photons, but the existing tool in CMSSW was written with MINIAOD in mind and would not quite work with AOD. Reimplementation here - hopefully we can get rid of it by the next release.
