### PR TITLE
updating to latest Puppi recipe

### DIFF
--- a/Producers/interface/PuppiPhotonScaler.h
+++ b/Producers/interface/PuppiPhotonScaler.h
@@ -30,15 +30,18 @@ class PuppiPhotonScaler : public edm::stream::EDProducer<> {
 
  private:
  virtual void produce(edm::Event&, const edm::EventSetup&);
- bool matchPFCandidate(reco::PFCandidate const&, reco::Candidate const&) const;
+ bool matchCandidate(reco::Candidate const&, reco::Candidate const&) const;
 
  edm::EDGetTokenT<PFView> tokenPFCandidates_;
- edm::EDGetTokenT<PFView> tokenPuppiCandidates_;
+ edm::EDGetTokenT<CandidateView> tokenPuppiCandidates_;
  edm::EDGetTokenT<CandidateView> tokenPhotonCandidates_;
  edm::EDGetTokenT<PFRefVectorMap> tokenFootprints_;
  edm::EDGetTokenT<BoolMap> tokenPhotonId_; 
 
+ double defaultWeight_;
  double pt_;
+ double eta_;
+ bool matchByRef_;
  std::vector<double> dRMatch_;
  std::vector<unsigned> pdgIds_;
  bool usePhotonId_;

--- a/Producers/src/PuppiPhotonScaler.cc
+++ b/Producers/src/PuppiPhotonScaler.cc
@@ -12,19 +12,28 @@
 #include "DataFormats/Math/interface/deltaR.h"
 //Main File
 
+#include <set>
+
 typedef edm::ValueMap<reco::CandidatePtr> CandPtrMap;
 
 // ------------------------------------------------------------------------------------------
 PuppiPhotonScaler::PuppiPhotonScaler(const edm::ParameterSet& iConfig) :
   tokenPFCandidates_(consumes<PFView>(iConfig.getParameter<edm::InputTag>("candName"))),
-  tokenPuppiCandidates_(consumes<PFView>(iConfig.getParameter<edm::InputTag>("puppiCandName"))),
+  tokenPuppiCandidates_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("puppiCandName"))),
   tokenPhotonCandidates_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("photonName"))),
   tokenFootprints_(consumes<PFRefVectorMap>(iConfig.getParameter<edm::InputTag>("footprintsName"))),
   tokenPhotonId_(consumes<BoolMap>(iConfig.getParameter<edm::InputTag>("photonId"))),
+  defaultWeight_(iConfig.getParameter<double>("defaultWeight")),
   pt_(iConfig.getParameter<double>("pt")),
-  dRMatch_(iConfig.getParameter<std::vector<double>>("dRMatch")),
-  pdgIds_(iConfig.getParameter<std::vector<unsigned>>("pdgids"))
+  eta_(iConfig.getParameter<double>("eta")),
+  matchByRef_(true)
 {
+  if (iConfig.exists("dRMatch")) {
+    matchByRef_ = false;
+    dRMatch_ = iConfig.getParameter<std::vector<double>>("dRMatch");
+    pdgIds_ = iConfig.getParameter<std::vector<unsigned>>("pdgids");
+  }
+
   usePhotonId_ = !tokenPhotonId_.isUninitialized();
 
   produces<PFOutputCollection>();
@@ -50,9 +59,9 @@ PuppiPhotonScaler::produce(edm::Event& iEvent, const edm::EventSetup&)
   iEvent.getByToken(tokenFootprints_, hFPProduct);
   const PFRefVectorMap *footprints = hFPProduct.product();
 
-  edm::Handle<PFView> hPuppiProduct;
+  edm::Handle<CandidateView> hPuppiProduct;
   iEvent.getByToken(tokenPuppiCandidates_, hPuppiProduct);
-  const PFView *pupCol = hPuppiProduct.product();
+  const CandidateView *pupCol = hPuppiProduct.product();
 
   edm::Handle<PFView> hPFProduct;
   iEvent.getByToken(tokenPFCandidates_, hPFProduct);
@@ -68,12 +77,11 @@ PuppiPhotonScaler::produce(edm::Event& iEvent, const edm::EventSetup&)
     photonId = hPhotonId.product();
   }
 
-  std::vector<reco::PFCandidate const*> matchedPFs;
-  std::vector<uint16_t> matchedPFKeys;
+  std::vector<std::pair<reco::PFCandidate const*, uint16_t>> fpCands;
 
-  int iC(0);
+  int iC(-1);
   for (auto& photon : *phoCol) {
-    auto&& ptr(phoCol->ptrAt(iC++));
+    ++iC;
 
     if (!photon.isPhoton())
       continue;
@@ -81,64 +89,74 @@ PuppiPhotonScaler::produce(edm::Event& iEvent, const edm::EventSetup&)
     if (photon.pt() < pt_)
       continue;
 
-    if (usePhotonId_) {
-      if (!(*photonId)[ptr])
-        continue;
-    }
+    auto&& ptr(phoCol->ptrAt(iC));
+
+    if (usePhotonId_ && !(*photonId)[ptr])
+      continue;
 
     for (auto&& fpRef : (*footprints)[ptr]) {
       auto key(fpRef.key());
       auto& fpPF(*pfCol->ptrAt(key));
 
-      if (matchPFCandidate(fpPF, photon)) {
-        matchedPFKeys.push_back(key);
-        matchedPFs.push_back(&fpPF);
-      }
+      if (std::abs(fpPF.eta()) < eta_)
+        fpCands.emplace_back(&fpPF, key);
     }
   }
 
   std::vector<reco::CandidatePtr> values(hPFProduct->size());
   std::auto_ptr<PFOutputCollection> corrCandidates(new PFOutputCollection);
 
-  int iPF(0);
+  std::set<reco::PFCandidate const*> matchedFPs;
+
+  int iPup(0);
   for (auto& pupCand : *pupCol) {
-    auto&& pupKey(pupCol->refAt(iPF++).key());
+    unsigned pupKey(-1);
+    if (matchByRef_)
+      pupKey = pupCol->refAt(iPup++).key();
 
-    reco::PFCandidate pCand(pupCand);
+    LorentzVector pVec;
+    bool scaleP = (pupCand.pt() != 0.);
 
-    float pWeight = 1.;
+    for (auto& fpCand : fpCands) {
+      auto& fpPF(*fpCand.first);
 
-    for (unsigned iKey(0); iKey != matchedPFKeys.size(); ++iKey) {
-      auto& key(matchedPFKeys[iKey]);
+      if (matchByRef_) {
+        if (fpCand.second != pupKey)
+          continue;
+      }
+      else {
+        if (!matchCandidate(pupCand, fpPF))
+          continue;
+      }
 
-      if (key != pupKey)
-        continue;
+      // the lines below make no sense but that's what CMSSW does, as of 8_0_20.
+      // we overwrite the candidate momentum with the last matching footprint candidate
+      if (scaleP)
+        pVec = pupCand.p4() * defaultWeight_ * (fpPF.pt() / pupCand.pt());
+      else
+        pVec = fpPF.p4() * defaultWeight_;
 
-      // are we sure we want just the last matched candidate??
-      if (pupCand.pt() != 0)
-        pWeight = matchedPFs[iKey]->pt() / pupCand.pt();
-
-      matchedPFs[iKey] = 0; // candidate matched by key; not used any more
+      matchedFPs.insert(&fpPF);
     }
 
-    LorentzVector pVec(pupCand.p4());
-    if(pupCand.pt() != 0.)
-      pVec.SetPxPyPzE(pupCand.px() * pWeight, pupCand.py() * pWeight, pupCand.pz() * pWeight, pupCand.energy() * pWeight);
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(pupCand.pdgId());
 
-    pCand.setP4(pVec);
+    reco::PFCandidate pCand(pupCand.charge(), pVec, id);
     pCand.setSourceCandidatePtr(pupCand.sourceCandidatePtr(0));
     corrCandidates->push_back(pCand);
   }
 
   // Add the missing pfcandidates
-  for (auto* pf : matchedPFs) {
-    if (!pf)
+  for (auto& fpCand : fpCands) {
+    if (matchedFPs.find(fpCand.first) != matchedFPs.end())
       continue;
 
-    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(pf->pdgId());
+    auto& fpPF(*fpCand.first);
 
-    reco::PFCandidate pCand(pf->charge(), pf->p4(), id);
-    pCand.setSourceCandidatePtr(pf->sourceCandidatePtr(0));
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(fpPF.pdgId());
+
+    reco::PFCandidate pCand(fpPF.charge(), fpPF.p4() * defaultWeight_, id);
+    pCand.setSourceCandidatePtr(fpPF.sourceCandidatePtr(0));
     corrCandidates->push_back(pCand);
   }
 
@@ -156,14 +174,17 @@ PuppiPhotonScaler::produce(edm::Event& iEvent, const edm::EventSetup&)
 
 // ------------------------------------------------------------------------------------------
 bool
-PuppiPhotonScaler::matchPFCandidate(reco::PFCandidate const& pf, reco::Candidate const& photon) const
+PuppiPhotonScaler::matchCandidate(reco::Candidate const& pf, reco::Candidate const& photon) const
 {
   unsigned absId(std::abs(pf.pdgId()));
-  double dr(deltaR(pf.eta(), pf.phi(), photon.eta(), photon.phi()));
-  
-  for (unsigned iI(0); iI != pdgIds_.size(); ++iI) {
-    if (pdgIds_[iI] == absId && dr < dRMatch_[iI])
-      return true;
+  unsigned iI(0);
+  for (; iI != pdgIds_.size(); ++iI) {
+    if (pdgIds_[iI] == absId)
+      break;
   }
-  return false;
+  if (iI == pdgIds_.size())
+    return false;
+
+  double dr(deltaR(pf.eta(), pf.phi(), photon.eta(), photon.phi()));
+  return dr < dRMatch_[iI];
 }


### PR DESCRIPTION
PUPPI recipe includes PuppiPhotons, which assumes pat::Photons in CMSSW. Translated to using reco::Photons. This is an updated version for the latest recipe.
